### PR TITLE
Linear comp prox

### DIFF
--- a/modopt/opt/__init__.py
+++ b/modopt/opt/__init__.py
@@ -34,6 +34,11 @@ References
     Minimization, 2007, Journal of Fourier Analysis and Applications,
     14(5):877-905. [https://arxiv.org/abs/0711.1612]
 
+.. [CW2005] Combettes, P. L., and Wajs, V. R. (2005). Signal recovery by
+    proximal forward-backward splitting. Multiscale Modeling & Simulation,
+    4(4), 1168-1200.
+    [https://pdfs.semanticscholar.org/5697/4187b4d9a8757f4d8a6fd6facc8b4ad08240.pdf]
+
 """
 
 __all__ = ['cost', 'gradient', 'linear', 'algorithms', 'proximity', 'reweight']

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -279,8 +279,12 @@ class LinearCompositionProx(ProximityParent):
     a composition between an initial function whose proximity operator is known
     and an orthogonal linear function.
 
-    # TODO:
-    document parameters
+    Parameters
+    ----------
+    linear_op : class instance
+        Linear operator class
+    prox_op : class instance
+        Proximity operator class
     """
     def __init__(self, linear_op, prox_op):
         self.linear_op = linear_op

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -290,6 +290,22 @@ class LinearCompositionProx(ProximityParent):
 
 
     def _op_method(self, data, extra_factor=1.0):
+        r"""Operator method
+
+        This method returns the scaled version of the proximity operator as
+        given by Lemma 2.8 of [CW2005].
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Input data array
+        extra_factor : float
+            Additional multiplication factor
+
+        Returns
+        -------
+        np.ndarray result of the scaled proximity operator
+        """
         return self.linear_op.adj_op(
             self.prox_op.op(self.linear_op.op(data), extra_factor=extra_factor)
         )

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -290,9 +290,8 @@ class LinearCompositionProx(ProximityParent):
         # TODO: implement the op
         pass
 
-    def _cost_method(self):
-        # TODO: implement the cost method
-        pass
+    def _cost_method(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 class ProximityCombo(ProximityParent):

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -277,18 +277,22 @@ class LinearCompositionProx(ProximityParent):
 
     This class defines the proximity operator of a function given by
     a composition between an initial function whose proximity operator is known
-    and a linear function with a known inverse.
+    and an orthogonal linear function.
 
     # TODO:
     document parameters
     """
-    def __init__(self):
-        # TODO: implement init
-        pass
+    def __init__(self, linear_op, prox_op):
+        self.linear_op = linear_op
+        self.prox_op = prox_op
+        self.op = self._op_method
+        self.cost = self._cost_method
 
-    def _op_method(self):
-        # TODO: implement the op
-        pass
+
+    def _op_method(self, data, extra_factor=1.0):
+        return self.linear_op.adj_op(
+            self.prox_op.op(self.linear_op.op(data), extra_factor=extra_factor)
+        )
 
     def _cost_method(self, *args, **kwargs):
         raise NotImplementedError()

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -272,6 +272,29 @@ class LowRankMatrix(ProximityParent):
         return cost_val
 
 
+class LinearCompositionProx(ProximityParent):
+    """Proximity operator of a linear composition
+
+    This class defines the proximity operator of a function given by
+    a composition between an initial function whose proximity operator is known
+    and a linear function with a known inverse.
+
+    # TODO:
+    document parameters
+    """
+    def __init__(self):
+        # TODO: implement init
+        pass
+
+    def _op_method(self):
+        # TODO: implement the op
+        pass
+
+    def _cost_method(self):
+        # TODO: implement the cost method
+        pass
+
+
 class ProximityCombo(ProximityParent):
     r"""Proximity Combo
 

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -315,7 +315,13 @@ class LinearCompositionProx(ProximityParent):
         )
 
     def _cost_method(self, *args, **kwargs):
-        raise NotImplementedError()
+        """Calculate the cost function associated to the composed function
+
+        Returns
+        -------
+        float the cost of the associated composed function
+        """
+        return self.prox_op.cost(self.linear_op.op(args[0]), **kwargs)
 
 
 class ProximityCombo(ProximityParent):

--- a/modopt/tests/test_opt.py
+++ b/modopt/tests/test_opt.py
@@ -379,6 +379,10 @@ class ProximityTestCase(TestCase):
         self.lowrank = proximity.LowRankMatrix(10.0, thresh_type='hard')
         self.lowrank_ngole = proximity.LowRankMatrix(10.0, lowr_type='ngole',
                                                      operator=lambda x: x * 2)
+        self.linear_comp = proximity.LinearCompositionProx(
+            linear_op=linear.Identity(),
+            prox_op=self.sparsethresh,
+        )
         self.combo = proximity.ProximityCombo([self.identity, self.positivity])
         self.data1 = np.arange(9).reshape(3, 3).astype(float)
         self.data2 = np.array([[-0., -0., -0.], [0., 1., 2.], [3., 4., 5.]])
@@ -469,6 +473,13 @@ class ProximityTestCase(TestCase):
         npt.assert_almost_equal(self.lowrank.cost(self.data3, verbose=True),
                                 469.39132942464983,
                                 err_msg='Inccoret low rank cost.')
+
+    def test_linear_comp_prox(self):
+        npt.assert_array_equal(self.linear_comp.op(self.data1), self.data2,
+                               err_msg='Inccorect sparse threshold operation.')
+
+        npt.assert_equal(self.linear_comp.cost(self.data1, verbose=True),
+                         108.0, err_msg='Inccoret sparse threshold cost.')
 
     def test_proximity_combo(self):
 


### PR DESCRIPTION
This solves #36 .

RE the cost method: I don't really know why the general `*args` form was kept for the cost. I would guess that it's only ever the first argument (i.e. the data) that is used. As a matter of fact it's the only one used in the code as far as I see.