### PR TITLE
Dropped support for Python < v3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+
+matrix:
+    include:
+        - python: 3.5
+        - python: 3.6
+        - python: 3.7
+          dist: xenial
+          sudo: true
 
 # GitHub branch
 branches:
@@ -12,9 +16,7 @@ branches:
 # install package and dependencies
 install:
   - pip install coverage nose pytest pytest-cov
-  - pip install scikit-image
-  - if [[ $TRAVIS_PYTHON_VERSION > '3' ]]; then pip install astropy; fi
-  - if [[ $TRAVIS_PYTHON_VERSION < '3' ]]; then pip install astropy==2.0.9; fi
+  - pip install astropy scikit-image
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install numpy future scipy astropy progressbar2 sphinx sphinx-rtd-theme numpydoc travis-sphinx coveralls; fi
 
 # run unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ These issues should include the `help wanted` label.
 If you encounter difficulties installing ModOpt be sure to re-read the installation instructions provided. If you are still unable to install the package please remember to include the following details in the issue you raise:
 
 * your operating system and the corresponding version (*e.g.* macOS v10.14.1, Ubuntu v16.04.1, *etc.*),
-* the version of Python you are using (*e.g* v2.7.14, v3.6.7, *etc.*),
+* the version of Python you are using (*e.g* v3.6.7, *etc.*),
 * the python environment you are using (if any) and the corresponding version (*e.g.* virtualenv v16.1.0, conda v4.5.11, *etc.*),
 * the exact steps followed while attempting to install ModOpt
 * and the error message printed or a screen capture of the terminal output.
@@ -186,7 +186,7 @@ Coverage tests are implemented via [Coveralls](https://coveralls.io/). These tes
 
 All contributions should adhere to the following style guides currently implemented in ModOpt:
 
-1. All code should be compatible with the Python versions listed in `README.rst`. At present this requires backwards compatibility with Python 2.7.
+1. All code should be compatible with the Python versions listed in `README.rst`.
 
 1. All code should adhere to [PEP8](https://www.python.org/dev/peps/pep-0008/) standards.
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ModOpt
 ======
 
-|travis| |coveralls| |license| |python27| |python35| |python36|
+|travis| |coveralls| |license| |python35| |python36| |python37|
 
 .. |travis| image:: https://travis-ci.org/CEA-COSMIC/ModOpt.svg?branch=master
   :target: https://travis-ci.org/CEA-COSMIC/ModOpt
@@ -12,18 +12,18 @@ ModOpt
 .. |license| image:: https://img.shields.io/github/license/mashape/apistatus.svg
   :target: https://github.com/CEA-COSMIC/ModOpt/blob/master/LICENCE.txt
 
-.. |python27| image:: https://img.shields.io/badge/python-2.7-green.svg
-  :target: https://www.python.org/
-
 .. |python35| image:: https://img.shields.io/badge/python-3.5-green.svg
   :target: https://www.python.org/
 
 .. |python36| image:: https://img.shields.io/badge/python-3.6-green.svg
   :target: https://www.python.org/
 
+.. |python37| image:: https://img.shields.io/badge/python-3.7-green.svg
+  :target: https://www.python.org/
+
 :Author: Samuel Farrens `(samuel.farrens@cea.fr) <samuel.farrens@cea.fr>`_
 
-:Version: 1.3.2
+:Version: 1.4.0
 
 :Date: 10/07/2019
 
@@ -55,15 +55,13 @@ Required Packages
 In order to run the code in this repository the following packages must be
 installed:
 
-* |link-to-python| [Last tested with v2.7.15 and v3.7.0]
+* |link-to-python| [Last tested with v3.7.0]
 
-* |link-to-numpy| [Tested with v1.15.4]
+* |link-to-numpy| [Tested with v1.16.4]
 
-* |link-to-scipy| [Tested with v1.1.0]
+* |link-to-scipy| [Tested with v1.3.0]
 
-* |link-to-future| [Tested with v0.17.1]
-
-* |link-to-progressbar| [Tested with v3.38.0]
+* |link-to-progressbar| [Tested with v3.42.0]
 
 .. |link-to-python| raw:: html
 
@@ -80,11 +78,6 @@ installed:
   <a href="http://www.scipy.org/"
   target="_blank">Scipy</a>
 
-.. |link-to-future| raw:: html
-
-  <a href="http://python-future.org/quickstart.html"
-  target="_blank">Future</a>
-
 .. |link-to-progressbar| raw:: html
 
   <a href="https://progressbar-2.readthedocs.io/en/latest/"
@@ -95,11 +88,11 @@ Optional Packages
 
 The following packages can optionally be installed to add extra functionality:
 
-* |link-to-astropy| [Last tested with v3.0.5]
+* |link-to-astropy| [Last tested with v3.2.1]
 
-* |link-to-matplotlib| [Last tested with v3.0.2]
+* |link-to-matplotlib| [Last tested with v3.1.1]
 
-* |link-to-skimage| [Last tested with v0.14.1]
+* |link-to-skimage| [Last tested with v0.15.0]
 
 * |link-to-termcolor| [Last tested with v1.1.0]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,11 +6,18 @@
 ModOpt Documentation
 ======================
 
-:Author: Samuel Farrens <samuel.farrens@cea.fr>
+:Author: Samuel Farrens `(samuel.farrens@cea.fr) <samuel.farrens@cea.fr>`_
 
-:Version: 1.3.2
+:Version: 1.4.0
 
 :Date: 10/07/2019
+
+:Documentation: |link-to-docs|
+
+.. |link-to-docs| raw:: html
+
+  <a href="https://cea-cosmic.github.io/ModOpt/"
+  target="_blank">https://cea-cosmic.github.io/ModOpt/</a>
 
 ModOpt is a series of Modular Optimisation tools for solving inverse problems.
 
@@ -24,8 +31,6 @@ Contents
 
 2. `Installation`_
 
-3. `Package Contents`_
-
 Dependencies
 ============
 
@@ -35,15 +40,13 @@ Required Packages
 In order to run the code in this repository the following packages must be
 installed:
 
-* |link-to-python| [Last tested with v2.7.15 and v3.7.0]
+* |link-to-python| [Last tested with v3.7.0]
 
-* |link-to-numpy| [Tested with v1.15.4]
+* |link-to-numpy| [Tested with v1.16.4]
 
-* |link-to-scipy| [Tested with v1.1.0]
+* |link-to-scipy| [Tested with v1.3.0]
 
-* |link-to-future| [Tested with v0.17.1]
-
-* |link-to-progressbar| [Tested with v3.38.0]
+* |link-to-progressbar| [Tested with v3.42.0]
 
 .. |link-to-python| raw:: html
 
@@ -60,11 +63,6 @@ installed:
   <a href="http://www.scipy.org/"
   target="_blank">Scipy</a>
 
-.. |link-to-future| raw:: html
-
-  <a href="http://python-future.org/quickstart.html"
-  target="_blank">Future</a>
-
 .. |link-to-progressbar| raw:: html
 
   <a href="https://progressbar-2.readthedocs.io/en/latest/"
@@ -75,11 +73,11 @@ Optional Packages
 
 The following packages can optionally be installed to add extra functionality:
 
-* |link-to-astropy| [Last tested with v2.0.8 and v3.0.5]
+* |link-to-astropy| [Last tested with v3.2.1]
 
-* |link-to-matplotlib| [Last tested with v3.0.2]
+* |link-to-matplotlib| [Last tested with v3.1.1]
 
-* |link-to-skimage| [Last tested with v0.14.1]
+* |link-to-skimage| [Last tested with v0.15.0]
 
 * |link-to-termcolor| [Last tested with v1.1.0]
 
@@ -106,11 +104,11 @@ The following packages can optionally be installed to add extra functionality:
 Installation
 ============
 
-To clone the modopt repository from GitHub run the following command:
+To clone the ModOpt repository from GitHub run the following command:
 
 .. code-block:: bash
 
-  $ git clone https://github.com/cea-cosmic/modopt
+  $ git clone https://github.com/cea-cosmic/ModOpt
 
 To install using `easy_install` run the following command:
 

--- a/modopt/base/np_adjust.py
+++ b/modopt/base/np_adjust.py
@@ -9,7 +9,6 @@ Numpy functions.
 
 """
 
-from __future__ import division
 import numpy as np
 
 

--- a/modopt/base/transform.py
+++ b/modopt/base/transform.py
@@ -8,8 +8,6 @@ This module contains methods for transforming data.
 
 """
 
-from __future__ import division
-from builtins import range
 import numpy as np
 
 

--- a/modopt/info.py
+++ b/modopt/info.py
@@ -6,12 +6,12 @@ This module provides some basic information about the ModOpt package.
 
 :Author: Samuel Farrens <samuel.farrens@cea.fr>
 
-:Version: 1.3.2
+:Version: 1.4.0
 
 """
 
 # Package Version
-version_info = (1, 3, 2)
+version_info = (1, 4, 0)
 __version__ = '.'.join(str(c) for c in version_info)
 
 __about__ = ('ModOpt \n\n '

--- a/modopt/interface/log.py
+++ b/modopt/interface/log.py
@@ -8,7 +8,6 @@ This module contains methods for handing logging.
 
 """
 
-from __future__ import print_function
 import sys
 import logging
 

--- a/modopt/math/convolve.py
+++ b/modopt/math/convolve.py
@@ -8,8 +8,6 @@ This module contains methods for convolution.
 
 """
 
-from __future__ import division
-from builtins import zip
 import numpy as np
 import scipy.signal
 from modopt.base.np_adjust import rotate_stack

--- a/modopt/math/matrix.py
+++ b/modopt/math/matrix.py
@@ -8,8 +8,6 @@ This module contains methods for matrix operations.
 
 """
 
-from __future__ import division
-from builtins import range, zip
 import numpy as np
 from itertools import product
 

--- a/modopt/math/stats.py
+++ b/modopt/math/stats.py
@@ -8,8 +8,6 @@ This module contains methods for basic statistics.
 
 """
 
-from __future__ import division
-from builtins import zip
 import numpy as np
 from scipy.stats import chi2
 try:

--- a/modopt/opt/algorithms.py
+++ b/modopt/opt/algorithms.py
@@ -44,8 +44,6 @@ The following notation is used to implement the algorithms:
 
 """
 
-from __future__ import division, print_function
-from builtins import range, zip
 from inspect import getmro
 from progressbar import ProgressBar
 import numpy as np

--- a/modopt/opt/cost.py
+++ b/modopt/opt/cost.py
@@ -8,7 +8,6 @@ This module contains classes of different cost functions for optimization.
 
 """
 
-from __future__ import division, print_function
 import numpy as np
 from modopt.base.types import check_callable
 from modopt.plot.cost_plot import plotCost

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -8,8 +8,6 @@ This module contains classes of proximity operators for optimisation
 
 """
 
-from __future__ import print_function
-from builtins import range
 import numpy as np
 from modopt.base.types import check_callable
 from modopt.signal.noise import thresh

--- a/modopt/opt/reweight.py
+++ b/modopt/opt/reweight.py
@@ -8,7 +8,6 @@ This module contains classes for reweighting optimisation implementations
 
 """
 
-from __future__ import division, print_function
 import numpy as np
 from modopt.base.types import check_float
 

--- a/modopt/plot/cost_plot.py
+++ b/modopt/plot/cost_plot.py
@@ -8,7 +8,6 @@ This module contains methods for making plots.
 
 """
 
-from __future__ import print_function
 import numpy as np
 from modopt.interface.errors import warn
 try:

--- a/modopt/signal/filter.py
+++ b/modopt/signal/filter.py
@@ -8,7 +8,6 @@ This module contains methods for distance measurements in cosmology.
 
 """
 
-from __future__ import division
 import numpy as np
 from modopt.base.types import check_float
 

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -8,8 +8,6 @@ This module contains methods for thresholding singular values.
 
 """
 
-from __future__ import division
-from builtins import zip
 import numpy as np
 from scipy.linalg import svd
 from modopt.math.convolve import convolve

--- a/modopt/signal/validation.py
+++ b/modopt/signal/validation.py
@@ -6,7 +6,6 @@ This module contains methods for testing signal and operator properties.
 
 """
 
-from __future__ import print_function
 import numpy as np
 
 

--- a/modopt/signal/wavelet.py
+++ b/modopt/signal/wavelet.py
@@ -16,8 +16,6 @@ Sparse2D Repository: https://github.com/CosmoStat/Sparse2D
 
 """
 
-from __future__ import division
-from builtins import zip
 import numpy as np
 import subprocess as sp
 from os import remove

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,10 @@ setup(
     url='https://github.com/cea-cosmic/ModOpt',
     download_url='https://github.com/cea-cosmic/ModOpt',
     packages=find_packages(),
-    install_requires=['numpy==1.16.0', 'future>=0.16.0', 'scipy==1.2.1',
-                      'progressbar2>=3.34.3'],
+    install_requires=['numpy>=1.16.4', 'scipy==1.3.0', 'progressbar2>=3.34.3'],
     license='MIT',
     description='Modular Optimisation tools for soliving inverse problems.',
     long_description=release_info["__about__"],
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest==4.6.4', 'pytest-cov==2.5.1', 'pytest-pep8'],
+    tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8'],
 )


### PR DESCRIPTION
- Removed all dependencies on `future`
- Removed imports from `builtins`
- Updated documentation
- Set minimum versions of package dependencies to latest, which only support Python v3.5+
- Added travis build for Python v3.7
- Updated package version to 1.4.0