### PR TITLE
Fix dependency of scipy, make it scipy>=1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/cea-cosmic/ModOpt',
     download_url='https://github.com/cea-cosmic/ModOpt',
     packages=find_packages(),
-    install_requires=['numpy>=1.16.4', 'scipy==1.3.0', 'progressbar2>=3.34.3'],
+    install_requires=['numpy>=1.16.4', 'scipy>=1.3.0', 'progressbar2>=3.34.3'],
     license='MIT',
     description='Modular Optimisation tools for soliving inverse problems.',
     long_description=release_info["__about__"],


### PR DESCRIPTION
This PR fixes the dependency issues with PySAP, as earlier ModOpt forces one particular version of scipy, which causes a chain of issues that percolated to numpy, astropy etc.