### PR TITLE
Ensure cost is never calculated in if `cost_interval=None` and call metrics at last iteration

### DIFF
--- a/modopt/opt/algorithms.py
+++ b/modopt/opt/algorithms.py
@@ -68,7 +68,7 @@ class SetUp(Observable):
         self.converge = False
         self.verbose = verbose
         self.progress = progress
-
+        self.metrics = metrics
         self._op_parents = ('GradParent', 'ProximityParent', 'LinearParent',
                             'costObj')
 
@@ -189,8 +189,14 @@ class SetUp(Observable):
             self._update()
 
             # Calling metrics every metric_call_period cycle
-            if self.idx % self.metric_call_period == 0:
-                self._compute_metrics()
+            # Also calculate at the end (max_iter or at convergence)
+            # We do not call metrics if metrics is empty or metric call
+            # period is None
+            if self.metrics and self.metric_call_period is not None:
+                if self.idx % self.metric_call_period == 0 or \
+                        self.idx == (max_iter - 1) or \
+                        self.converge:
+                    self._compute_metrics()
 
             if self.converge and self.verbose:
                 print(' - Converged!')

--- a/modopt/opt/cost.py
+++ b/modopt/opt/cost.py
@@ -29,7 +29,9 @@ class costObj(object):
     tolerance : float, optional
         Tolerance threshold for convergence (default is "1e-4")
     cost_interval : int, optional
-        Iteration interval to calculate cost (default is "1")
+        Iteration interval to calculate cost (default is "None").
+        If `cost_interval` is `None` the cost is never calculated,
+        thereby saving on computation time.
     test_range : int, optional
         Number of cost values to be used in test (default is "4")
     verbose : bool, optional
@@ -77,7 +79,7 @@ class costObj(object):
     """
 
     def __init__(self, operators, initial_cost=1e6, tolerance=1e-4,
-                 cost_interval=1, test_range=4, verbose=True,
+                 cost_interval=None, test_range=4, verbose=True,
                  plot_output=None):
 
         self._operators = operators
@@ -183,7 +185,9 @@ class costObj(object):
         """
 
         # Check if the cost should be calculated
-        if self._iteration % self._cost_interval:
+        if self._cost_interval is None:
+            test_result = False
+        elif self._iteration % self._cost_interval:
 
             test_result = False
 

--- a/modopt/opt/cost.py
+++ b/modopt/opt/cost.py
@@ -79,7 +79,7 @@ class costObj(object):
     """
 
     def __init__(self, operators, initial_cost=1e6, tolerance=1e-4,
-                 cost_interval=None, test_range=4, verbose=True,
+                 cost_interval=1, test_range=4, verbose=True,
                  plot_output=None):
 
         self._operators = operators

--- a/modopt/opt/cost.py
+++ b/modopt/opt/cost.py
@@ -29,7 +29,7 @@ class costObj(object):
     tolerance : float, optional
         Tolerance threshold for convergence (default is "1e-4")
     cost_interval : int, optional
-        Iteration interval to calculate cost (default is "None").
+        Iteration interval to calculate cost (default is "1").
         If `cost_interval` is `None` the cost is never calculated,
         thereby saving on computation time.
     test_range : int, optional

--- a/modopt/opt/cost.py
+++ b/modopt/opt/cost.py
@@ -185,9 +185,8 @@ class costObj(object):
         """
 
         # Check if the cost should be calculated
-        if self._cost_interval is None:
-            test_result = False
-        elif self._iteration % self._cost_interval:
+        if self._cost_interval is None or \
+                self._iteration % self._cost_interval:
 
             test_result = False
 

--- a/modopt/tests/test_opt.py
+++ b/modopt/tests/test_opt.py
@@ -211,9 +211,9 @@ class CostTestCase(TestCase):
         self.inst2 = cost.costObj([dummy_inst1, dummy_inst2], cost_interval=2)
         [self.inst2.get_cost(2) for i in range(6)]
         # Test that by default cost of False if interval is None
-        self.inst_default = cost.costObj([dummy_inst1, dummy_inst2],
+        self.inst_none = cost.costObj([dummy_inst1, dummy_inst2],
                                          cost_interval=None)
-        [self.inst_default.get_cost(2) for i in range(6)]
+        [self.inst_none.get_cost(2) for i in range(6)]
         self.dummy = dummy()
 
     def tearDown(self):
@@ -226,7 +226,7 @@ class CostTestCase(TestCase):
                          err_msg='Incorrect cost test result.')
         npt.assert_equal(self.inst1.get_cost(2), True,
                          err_msg='Incorrect cost test result.')
-        npt.assert_equal(self.inst_default.get_cost(2), False,
+        npt.assert_equal(self.inst_none.get_cost(2), False,
                          err_msg='Incorrect cost test result.')
 
         npt.assert_equal(self.inst1.cost, 12, err_msg='Incorrect cost value.')

--- a/modopt/tests/test_opt.py
+++ b/modopt/tests/test_opt.py
@@ -210,6 +210,10 @@ class CostTestCase(TestCase):
         [self.inst1.get_cost(2) for i in range(2)]
         self.inst2 = cost.costObj([dummy_inst1, dummy_inst2], cost_interval=2)
         [self.inst2.get_cost(2) for i in range(6)]
+        # Test that by default cost of False if interval is None
+        self.inst_default = cost.costObj([dummy_inst1, dummy_inst2],
+                                         cost_interval=None)
+        [self.inst_default.get_cost(2) for i in range(6)]
         self.dummy = dummy()
 
     def tearDown(self):
@@ -220,8 +224,9 @@ class CostTestCase(TestCase):
 
         npt.assert_equal(self.inst1.get_cost(2), False,
                          err_msg='Incorrect cost test result.')
-
         npt.assert_equal(self.inst1.get_cost(2), True,
+                         err_msg='Incorrect cost test result.')
+        npt.assert_equal(self.inst_default.get_cost(2), False,
                          err_msg='Incorrect cost test result.')
 
         npt.assert_equal(self.inst1.cost, 12, err_msg='Incorrect cost value.')

--- a/modopt/tests/test_opt.py
+++ b/modopt/tests/test_opt.py
@@ -212,7 +212,7 @@ class CostTestCase(TestCase):
         [self.inst2.get_cost(2) for i in range(6)]
         # Test that by default cost of False if interval is None
         self.inst_none = cost.costObj([dummy_inst1, dummy_inst2],
-                                         cost_interval=None)
+                                      cost_interval=None)
         [self.inst_none.get_cost(2) for i in range(6)]
         self.dummy = dummy()
 


### PR DESCRIPTION
This PR resolves #87 :
With this PR, the cost is **never** calculated by default, however, the user has an option to allow for the computation of cost at every Nth iteration as earlier.\

As this is a small PR, it also resolves #84 
