### PR TITLE
Update flag for convergence

### DIFF
--- a/modopt/opt/algorithms.py
+++ b/modopt/opt/algorithms.py
@@ -233,8 +233,9 @@ class SetUp(Observable):
                         self.converge:
                     self._compute_metrics()
 
-            if self.converge and self.verbose:
-                print(' - Converged!')
+            if self.converge:
+                if self.verbose:
+                    print(' - Converged!')
                 break
 
             if not isinstance(bar, type(None)):


### PR DESCRIPTION
Currently, we converge and break only if verbosity is on. Switching it so that the functions that converge can be reported also!
