### PR TITLE
MInor bug in `get_array_module`

### DIFF
--- a/modopt/base/backend.py
+++ b/modopt/base/backend.py
@@ -95,7 +95,7 @@ def get_array_module(input_data):
     if LIBRARIES['tensorflow'] is not None:
         if isinstance(input_data, LIBRARIES['tensorflow'].ndarray):
             return LIBRARIES['tensorflow']
-    elif LIBRARIES['cupy'] is not None:
+    if LIBRARIES['cupy'] is not None:
         if isinstance(input_data, LIBRARIES['cupy'].ndarray):
             return LIBRARIES['cupy']
     return np


### PR DESCRIPTION
It looks like we had an else if when we merged the tensorflow GPU codes.

This used to send numpy as the module in bad cases. This is a minor but good fix for the release.