### PR TITLE
Add tests for modopt.base.backend and fix minute bug uncovered

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install -r develop.txt
           python -m pip install -r docs/requirements.txt
           python -m pip install astropy scikit-image scikit-learn
-          python -m pip install tensorflow>=2.4.1 cupy
+          python -m pip install tensorflow>=2.4.1
           python -m pip install twine
           python -m pip install .
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,6 +53,7 @@ jobs:
           python -m pip install -r develop.txt
           python -m pip install -r docs/requirements.txt
           python -m pip install astropy scikit-image scikit-learn
+          python -m pip install tensorflow>=2.4.1 cupy
           python -m pip install twine
           python -m pip install .
 

--- a/modopt/base/backend.py
+++ b/modopt/base/backend.py
@@ -95,7 +95,7 @@ def get_array_module(input_data):
     if LIBRARIES['tensorflow'] is not None:
         if isinstance(input_data, LIBRARIES['tensorflow'].ndarray):
             return LIBRARIES['tensorflow']
-    elif LIBRARIES['cupy'] is not None:
+    if LIBRARIES['cupy'] is not None:
         if isinstance(input_data, LIBRARIES['cupy'].ndarray):
             return LIBRARIES['cupy']
     return np

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -290,7 +290,7 @@ class TestBackend(TestCase):
     def test_tf_backend(self):
         """Test tensorflow backend."""
         xp, backend = get_backend('tensorflow')
-        if backend != ':tensorflow' or xp != LIBRARIES['tensorflow']:
+        if backend != 'tensorflow' or xp != LIBRARIES['tensorflow']:
             raise AssertionError('tensorflow get_backend fails!')
         tf_input = change_backend(self.input, 'tensorflow')
         if (

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -9,12 +9,13 @@ This module contains unit tests for the modopt.base module.
 """
 
 from builtins import range
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 import numpy as np
 import numpy.testing as npt
 
 from modopt.base import np_adjust, transform, types
+from modopt.base.backend import LIBRARIES, get_array_module, change_backend, get_backend
 
 
 class NPAdjustTestCase(TestCase):
@@ -275,3 +276,28 @@ class TypesTestCase(TestCase):
             self.data3,
             dtype=np.integer,
         )
+
+
+class TestBackend(TestCase):
+    """Test the backend codes."""
+    def setUp(self):
+        self.input = np.array([10, 10])
+
+    @skipIf(LIBRARIES['tensorflow'] is None, "tensorflow library not installed")
+    def test_tf_backend(self):
+        tf_input, backend = change_backend(self.input, 'tensorflow')
+        if get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow'] or
+            get_array_module(tf_input) != LIBRARIES['tensorflow'] or
+            backend != 'cupy':
+            assert "tensorflow backend fails!"
+
+    @skipIf(LIBRARIES['cupy'] is None, "cupy library not installed")
+    def test_cp_backend(self):
+        cp_input, backend = change_backend(self.input, 'cupy')
+        if get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy'] or
+            get_array_module(cp_input) != LIBRARIES['cupy'] or
+            backend != 'cupy':
+            assert "cupy backend fails!"
+
+    def tearDown(self):
+        self.input = None

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -15,7 +15,7 @@ import numpy as np
 import numpy.testing as npt
 
 from modopt.base import np_adjust, transform, types
-from modopt.base.backend import change_backend, get_array_module, get_backend, LIBRARIES
+from modopt.base.backend import LIBRARIES, change_backend, get_array_module, get_backend
 
 
 class NPAdjustTestCase(TestCase):

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -14,8 +14,9 @@ from unittest import TestCase, skipIf
 import numpy as np
 import numpy.testing as npt
 
+from modopt.base.backend import LIBRARIES, get_array_module
+from modopt.base.backend import change_backend, get_backend
 from modopt.base import np_adjust, transform, types
-from modopt.base.backend import LIBRARIES, get_array_module, change_backend, get_backend
 
 
 class NPAdjustTestCase(TestCase):
@@ -280,24 +281,42 @@ class TypesTestCase(TestCase):
 
 class TestBackend(TestCase):
     """Test the backend codes."""
+
     def setUp(self):
+        """Setup class for doing tests."""
         self.input = np.array([10, 10])
 
     @skipIf(LIBRARIES['tensorflow'] is None, "tensorflow library not installed")
     def test_tf_backend(self):
-        tf_input, backend = change_backend(self.input, 'tensorflow')
+        """Test tensorflow backend."""
+        xp, backend = get_backend('tensorflow')
+        if backend != 'tensorflow' or xp != LIBRARIES['tensorflow']:
+            assert "tensorflow get_backend fails!"
+        tf_input = change_backend(self.input, 'tensorflow')
         if (get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow'] or
-            get_array_module(tf_input) != LIBRARIES['tensorflow'] or
-            backend != 'tensorflow'):
+            get_array_module(tf_input) != LIBRARIES['tensorflow']):
             assert "tensorflow backend fails!"
 
     @skipIf(LIBRARIES['cupy'] is None, "cupy library not installed")
     def test_cp_backend(self):
-        cp_input, backend = change_backend(self.input, 'cupy')
+        """Test cupy backend."""
+        xp, backend = get_backend('cupy')
+        if backend != 'cupy' or xp != LIBRARIES['cupy']:
+            assert "cupy get_backend fails!"
+        cp_input = change_backend(self.input, 'cupy')
         if (get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy'] or
-            get_array_module(cp_input) != LIBRARIES['cupy'] or
-            backend != 'cupy'):
+            get_array_module(cp_input) != LIBRARIES['cupy']):
             assert "cupy backend fails!"
+
+    def test_np_backend(self):
+        """Test numpy backend."""
+        xp, backend = get_backend('numpy')
+        if backend != 'numpy' or xp != LIBRARIES['numpy']:
+            assert "numpy get_backend fails!"
+        np_input = change_backend(self.input, 'numpy')
+        if (get_array_module(LIBRARIES['numpy'].ones(1)) != LIBRARIES['numpy'] or
+            get_array_module(np_input) != LIBRARIES['numpy']):
+            assert "numpy backend fails!"
 
     def tearDown(self):
         self.input = None

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -286,17 +286,17 @@ class TestBackend(TestCase):
     @skipIf(LIBRARIES['tensorflow'] is None, "tensorflow library not installed")
     def test_tf_backend(self):
         tf_input, backend = change_backend(self.input, 'tensorflow')
-        if get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow'] or
+        if (get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow'] or
             get_array_module(tf_input) != LIBRARIES['tensorflow'] or
-            backend != 'cupy':
+            backend != 'tensorflow'):
             assert "tensorflow backend fails!"
 
     @skipIf(LIBRARIES['cupy'] is None, "cupy library not installed")
     def test_cp_backend(self):
         cp_input, backend = change_backend(self.input, 'cupy')
-        if get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy'] or
+        if (get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy'] or
             get_array_module(cp_input) != LIBRARIES['cupy'] or
-            backend != 'cupy':
+            backend != 'cupy'):
             assert "cupy backend fails!"
 
     def tearDown(self):

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -15,7 +15,8 @@ import numpy as np
 import numpy.testing as npt
 
 from modopt.base import np_adjust, transform, types
-from modopt.base.backend import LIBRARIES, change_backend, get_array_module, get_backend
+from modopt.base.backend import LIBRARIES
+from modopt.base.backend import change_backend, get_array_module, get_backend
 
 
 class NPAdjustTestCase(TestCase):

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -14,9 +14,8 @@ from unittest import TestCase, skipIf
 import numpy as np
 import numpy.testing as npt
 
-from modopt.base.backend import LIBRARIES, get_array_module
-from modopt.base.backend import change_backend, get_backend
 from modopt.base import np_adjust, transform, types
+from modopt.base.backend import change_backend, get_array_module, get_backend, LIBRARIES
 
 
 class NPAdjustTestCase(TestCase):
@@ -283,40 +282,47 @@ class TestBackend(TestCase):
     """Test the backend codes."""
 
     def setUp(self):
-        """Setup class for doing tests."""
+        """Set test parameter values."""
         self.input = np.array([10, 10])
 
-    @skipIf(LIBRARIES['tensorflow'] is None, "tensorflow library not installed")
+    @skipIf(LIBRARIES['tensorflow'] is None, 'tensorflow library not installed')
     def test_tf_backend(self):
         """Test tensorflow backend."""
         xp, backend = get_backend('tensorflow')
-        if backend != 'tensorflow' or xp != LIBRARIES['tensorflow']:
-            assert "tensorflow get_backend fails!"
+        if backend != ':tensorflow' or xp != LIBRARIES['tensorflow']:
+            raise AssertionError('tensorflow get_backend fails!')
         tf_input = change_backend(self.input, 'tensorflow')
-        if (get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow'] or
-            get_array_module(tf_input) != LIBRARIES['tensorflow']):
-            assert "tensorflow backend fails!"
+        if (
+            get_array_module(LIBRARIES['tensorflow'].ones(1)) != LIBRARIES['tensorflow']
+            or get_array_module(tf_input) != LIBRARIES['tensorflow']
+        ):
+            raise AssertionError('tensorflow backend fails!')
 
-    @skipIf(LIBRARIES['cupy'] is None, "cupy library not installed")
+    @skipIf(LIBRARIES['cupy'] is None, 'cupy library not installed')
     def test_cp_backend(self):
         """Test cupy backend."""
         xp, backend = get_backend('cupy')
         if backend != 'cupy' or xp != LIBRARIES['cupy']:
-            assert "cupy get_backend fails!"
+            raise AssertionError('cupy get_backend fails!')
         cp_input = change_backend(self.input, 'cupy')
-        if (get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy'] or
-            get_array_module(cp_input) != LIBRARIES['cupy']):
-            assert "cupy backend fails!"
+        if (
+            get_array_module(LIBRARIES['cupy'].ones(1)) != LIBRARIES['cupy']
+            or get_array_module(cp_input) != LIBRARIES['cupy']
+        ):
+            raise AssertionError('cupy backend fails!')
 
     def test_np_backend(self):
         """Test numpy backend."""
         xp, backend = get_backend('numpy')
         if backend != 'numpy' or xp != LIBRARIES['numpy']:
-            assert "numpy get_backend fails!"
+            raise AssertionError('numpy get_backend fails!')
         np_input = change_backend(self.input, 'numpy')
-        if (get_array_module(LIBRARIES['numpy'].ones(1)) != LIBRARIES['numpy'] or
-            get_array_module(np_input) != LIBRARIES['numpy']):
-            assert "numpy backend fails!"
+        if (
+            get_array_module(LIBRARIES['numpy'].ones(1)) != LIBRARIES['numpy']
+            or get_array_module(np_input) != LIBRARIES['numpy']
+        ):
+            raise AssertionError('numpy backend fails!')
 
     def tearDown(self):
+        """Tear Down of objects."""
         self.input = None

--- a/modopt/tests/test_base.py
+++ b/modopt/tests/test_base.py
@@ -15,8 +15,8 @@ import numpy as np
 import numpy.testing as npt
 
 from modopt.base import np_adjust, transform, types
-from modopt.base.backend import LIBRARIES
-from modopt.base.backend import change_backend, get_array_module, get_backend
+from modopt.base.backend import (LIBRARIES, change_backend, get_array_module,
+                                 get_backend)
 
 
 class NPAdjustTestCase(TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ per-file-ignores =
   modopt/signal/wavelet.py: S404,S603
   #Todo: Clean up tests
   modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604
-  #Todo: Import has bad paramthesis
+  #Todo: Import has bad parenthesis
   modopt/tests/test_base.py: WPS318,WPS319,E501,WPS301
 #WPS Settings
 max-arguments = 25

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ per-file-ignores =
   modopt/signal/wavelet.py: S404,S603
   #Todo: Clean up tests
   modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604,E501
+  #Todo: Import has bad paramthesis
+  modopt/tests/test_base.py: WPS318,WPS319
 #WPS Settings
 max-arguments = 25
 max-attributes = 40

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,9 +54,9 @@ per-file-ignores =
   #Todo: Check security of using system executable call
   modopt/signal/wavelet.py: S404,S603
   #Todo: Clean up tests
-  modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604,E501
+  modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604
   #Todo: Import has bad paramthesis
-  modopt/tests/test_base.py: WPS318,WPS319
+  modopt/tests/test_base.py: WPS318,WPS319,E501,WPS301
 #WPS Settings
 max-arguments = 25
 max-attributes = 40

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ per-file-ignores =
   #Todo: Check security of using system executable call
   modopt/signal/wavelet.py: S404,S603
   #Todo: Clean up tests
-  modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604
+  modopt/tests/*.py: E731,F401,WPS301,WPS420,WPS425,WPS437,WPS604,E501
 #WPS Settings
 max-arguments = 25
 max-attributes = 40


### PR DESCRIPTION
These tests run only if tensorflow and cupy are installed.
@sfarrens can we add this to be tested with installs? 

I am not sure how long it will take to run.

ALso, these tests found a minute but a crucial bug which could be included in the release.

