### PR TITLE
Unpin package dependencies

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -7,5 +7,8 @@ label_prs: update
 assignees: sfarrens
 requirements:
   - requirements.txt
+      pin: False
   - develop.txt
+      pin: False
   - docs/requirements.txt
+      pin: True

--- a/develop.txt
+++ b/develop.txt
@@ -1,8 +1,8 @@
-coverage==5.5
-nose==1.3.7
-pytest==6.2.2
-pytest-cov==2.11.1
-pytest-pep8==1.0.6
-pytest-emoji==0.2.0
-pytest-flake8==1.0.7
-wemake-python-styleguide==0.15.2
+coverage>=5.5
+nose>=1.3.7
+pytest>=6.2.2
+pytest-cov>=2.11.1
+pytest-pep8>=1.0.6
+pytest-emoji>=0.2.0
+pytest-flake8>=1.0.7
+wemake-python-styleguide>=0.15.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 jupyter==1.0.0
-nbsphinx==0.8.2
+nbsphinx==0.8.7
 nbsphinx-link==1.3.0
 numpydoc==1.1.0
-sphinx==3.5.2
-sphinxcontrib-bibtex==2.2.0
-sphinxawesome-theme==1.19.2
+sphinx==4.3.0
+sphinxcontrib-bibtex==2.4.1
+sphinxawesome-theme==3.2.0

--- a/docs/source/dependencies.rst
+++ b/docs/source/dependencies.rst
@@ -12,10 +12,10 @@ Required Packages
 In order to use ModOpt the following packages must be installed:
 
 * |link-to-python| ``[> 3.6]``
-* |link-to-metadata| ``[==3.7.0]``
-* |link-to-numpy| ``[==1.19.5]``
-* |link-to-scipy| ``[==1.5.4]``
-* |link-to-progressbar| ``[==3.53.1]``
+* |link-to-metadata| ``[>=3.7.0]``
+* |link-to-numpy| ``[>=1.19.5]``
+* |link-to-scipy| ``[>=1.5.4]``
+* |link-to-progressbar| ``[>=3.53.1]``
 
 .. |link-to-python| raw:: html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-importlib_metadata==3.7.0
-numpy==1.19.5
-scipy==1.5.4
-progressbar2==3.53.1
+importlib_metadata>=3.7.0
+numpy>=1.19.5
+scipy>=1.5.4
+progressbar2>=3.53.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 test=pytest
 
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [darglint]
 docstring_style = numpy


### PR DESCRIPTION
## Summary

- closes #144
- closes #169
- closes ModOpt part of [this issue](https://github.com/CEA-COSMIC/pysap/issues/164)
- unpinned package and development requirements and set minimum versions
- updated `.pyup.yml` to prevent it from opening PRs to pin these dependencies
- updated pinned versions for API documentation build dependencies (these should not impact users)
- updated `description-file` -> `description_file` in `setup.cfg` (to remove deprecation warning)