### PR TITLE
Fast Singular Value Thresholding 

### DIFF
--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -14,7 +14,6 @@ This module contains classes of proximity operators for optimisation.
 import sys
 
 import numpy as np
-import scipy as sp
 
 try:
     from sklearn.isotonic import isotonic_regression
@@ -27,7 +26,6 @@ from modopt.base.transform import cube2matrix, matrix2cube
 from modopt.base.types import check_callable
 from modopt.interface.errors import warn
 from modopt.math.matrix import nuclear_norm
-from modopt.opt.linear import Identity
 from modopt.signal.noise import thresh
 from modopt.signal.positivity import positive
 from modopt.signal.svd import svd_thresh, svd_thresh_coef, svd_thresh_coef_fast
@@ -297,14 +295,16 @@ class LowRankMatrix(ProximityParent):
         rank: int, optional
             An estimation of the rank to save computation in standard mode.
             Else use an internal estimation.
+
         Returns
         -------
         numpy.ndarray
             SVD thresholded data
+
         Raises
         ------
         ValueError
-            if lowr_type is not in ``{'standard', 'ngole'}
+            if lowr_type is not in ``{'standard', 'ngole'}``
         """
         # Update threshold with extra factor.
         threshold = self.thresh * extra_factor
@@ -332,7 +332,7 @@ class LowRankMatrix(ProximityParent):
                 thresh_type=self.thresh_type,
             )
         else:
-            raise ValueError("lowr_type should be standard, ngole or fast.")
+            raise ValueError('lowr_type should be standard or ngole')
 
         # Return updated data.
         return matrix2cube(data_matrix, input_data.shape[1:])

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -237,6 +237,9 @@ class LowRankMatrix(ProximityParent):
     lowr_type : {'standard', 'ngole'}
         Low-rank implementation (options are 'standard' or 'ngole', default is
         'standard')
+    initial_rank: int, optional
+        Initial guess of the rank of future input_data.
+        If provided this will save computation time.
     operator : class
         Operator class ('ngole' only)
 
@@ -293,8 +296,8 @@ class LowRankMatrix(ProximityParent):
         extra_factor : float
             Additional multiplication factor (default is ``1.0``)
         rank: int, optional
-            An estimation of the rank to save computation in standard mode.
-            An estimation of the rank to save computation time in standard mode, if not set an internal estimation is used.
+            Estimation of the rank to save computation time in standard mode,
+            if not set an internal estimation is used.
 
         Returns
         -------

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -294,7 +294,7 @@ class LowRankMatrix(ProximityParent):
             Additional multiplication factor (default is ``1.0``)
         rank: int, optional
             An estimation of the rank to save computation in standard mode.
-            Else use an internal estimation.
+            An estimation of the rank to save computation time in standard mode, if not set an internal estimation is used.
 
         Returns
         -------

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -9,12 +9,14 @@ This module contains methods for thresholding singular values.
 """
 
 import numpy as np
+from scipy.linalg import svd
+from scipy.sparse.linalg import svds
+
 from modopt.base.transform import matrix2cube
 from modopt.interface.errors import warn
 from modopt.math.convolve import convolve
 from modopt.signal.noise import thresh
-from scipy.linalg import svd
-from scipy.sparse.linalg import svds
+
 
 def find_n_pc(u_vec, factor=0.5):
     """Find number of principal components.
@@ -209,7 +211,7 @@ def svd_thresh_coef_fast(
     """Threshold the singular values coefficients.
 
     This method thresholds the input data by using singular value
-    decomposition, but only computing the the greastest ``n_vals`` 
+    decomposition, but only computing the the greastest ``n_vals``
     values.
 
     Parameters
@@ -231,7 +233,7 @@ def svd_thresh_coef_fast(
     Returns
     -------
     tuple
-        The thresholded data (numpy.ndarray) and the estimated rank after 
+        The thresholded data (numpy.ndarray) and the estimated rank after
         thresholding (int)
     """
     if n_vals == -1:

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -231,10 +231,8 @@ def svd_thresh_coef_fast(
 
     Returns
     -------
-    numpy.ndarray
-        Thresholded data
-    int
-        the estimated rank after thresholding.
+    tuple
+        The thresholded data (numpy.ndarray) and the estimated rank after thresholding (int)
     """
     if n_vals == -1:
         n_vals = min(input_data.shape) - 1

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -9,14 +9,12 @@ This module contains methods for thresholding singular values.
 """
 
 import numpy as np
-from scipy.linalg import svd
-from scipy.sparse.linalg import svds
-
 from modopt.base.transform import matrix2cube
 from modopt.interface.errors import warn
 from modopt.math.convolve import convolve
 from modopt.signal.noise import thresh
-
+from scipy.linalg import svd
+from scipy.sparse.linalg import svds
 
 def find_n_pc(u_vec, factor=0.5):
     """Find number of principal components.

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -231,7 +231,8 @@ def svd_thresh_coef_fast(
     Returns
     -------
     tuple
-        The thresholded data (numpy.ndarray) and the estimated rank after thresholding (int)
+        The thresholded data (numpy.ndarray) and the estimated rank after 
+        thresholding (int)
     """
     if n_vals == -1:
         n_vals = min(input_data.shape) - 1

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -202,11 +202,12 @@ def svd_thresh(input_data, threshold=None, n_pc=None, thresh_type='hard'):
 
 
 def svd_thresh_coef_fast(
-        input_data,
-        threshold,
-        n_vals=None,
-        extra_vals=5,
-        thresh_type='hard'):
+    input_data,
+    threshold,
+    n_vals=-1,
+    extra_vals=5,
+    thresh_type='hard',
+):
     """Threshold the singular values coefficients.
 
     This method threshold the input data by using singular value decomposition,
@@ -219,7 +220,7 @@ def svd_thresh_coef_fast(
         Operator class instance
     threshold : float or numpy.ndarray
         Threshold value(s)
-    n_vals: int, default None
+    n_vals: int, optional
         Number of singular values to compute.
         If None, compute all singular values.
     extra_vals: int, optional
@@ -235,20 +236,27 @@ def svd_thresh_coef_fast(
     int
         the estimated rank after thresholding.
     """
-    n_vals = n_vals or min(input_data.shape) - 1
+    if n_vals == -1:
+        n_vals = min(input_data.shape) - 1
     ok = False
     while not ok:
         (u_vec, s_values, v_vec) = svds(input_data, k=n_vals)
         ok = (s_values[0] <= threshold or n_vals == min(input_data.shape) - 1)
         n_vals = min(n_vals + extra_vals, *input_data.shape)
 
-    s_values = thresh(s_values,
-                      threshold,
-                      threshold_type=thresh_type)
+    s_values = thresh(
+        s_values,
+        threshold,
+        threshold_type=thresh_type,
+    )
     rank = np.count_nonzero(s_values)
-    return (np.dot(u_vec[:, -rank:] * s_values[-rank:],
-                   v_vec[-rank:, :]),
-            rank)
+    return (
+        np.dot(
+            u_vec[:, -rank:] * s_values[-rank:],
+            v_vec[-rank:, :],
+        ),
+        rank,
+    )
 
 
 def svd_thresh_coef(input_data, operator, threshold, thresh_type='hard'):

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -208,8 +208,9 @@ def svd_thresh_coef_fast(
 ):
     """Threshold the singular values coefficients.
 
-    This method thresholds the input data by using singular value decomposition,
-    but only computing the the greastest ``n_vals``  values.
+    This method thresholds the input data by using singular value
+    decomposition, but only computing the the greastest ``n_vals`` 
+    values.
 
     Parameters
     ----------

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -10,6 +10,7 @@ This module contains methods for thresholding singular values.
 
 import numpy as np
 from scipy.linalg import svd
+from scipy.sparse.linalg import svds
 
 from modopt.base.transform import matrix2cube
 from modopt.interface.errors import warn
@@ -198,6 +199,56 @@ def svd_thresh(input_data, threshold=None, n_pc=None, thresh_type='hard'):
 
     # Return the thresholded data.
     return np.dot(u_vec, np.dot(s_new, v_vec))
+
+
+def svd_thresh_coef_fast(
+        input_data,
+        threshold,
+        n_vals=None,
+        extra_vals=5,
+        thresh_type='hard'):
+    """Threshold the singular values coefficients.
+
+    This method threshold the input data by using singular value decomposition,
+    but only computing the the greastest ``n_vals``  values.
+
+    Parameters
+    ----------
+    input_data : numpy.ndarray
+        Input data array, 2D matrix
+        Operator class instance
+    threshold : float or numpy.ndarray
+        Threshold value(s)
+    n_vals: int, default None
+        Number of singular values to compute.
+        If None, compute all singular values.
+    extra_vals: int, optional
+        If the number of values computed is not enough to perform thresholding,
+        recompute by using ``n_vals + extra_vals`` (default is ``5``)
+    thresh_type : {'hard', 'soft'}
+        Type of noise to be added (default is ``'hard'``)
+
+    Returns
+    -------
+    numpy.ndarray
+        Thresholded data
+    int
+        the estimated rank after thresholding.
+    """
+    n_vals = n_vals or min(input_data.shape) - 1
+    ok = False
+    while not ok:
+        (u_vec, s_values, v_vec) = svds(input_data, k=n_vals)
+        ok = (s_values[0] <= threshold or n_vals == min(input_data.shape) - 1)
+        n_vals = min(n_vals + extra_vals, *input_data.shape)
+
+    s_values = thresh(s_values,
+                      threshold,
+                      threshold_type=thresh_type)
+    rank = np.count_nonzero(s_values)
+    return (np.dot(u_vec[:, -rank:] * s_values[-rank:],
+                   v_vec[-rank:, :]),
+            rank)
 
 
 def svd_thresh_coef(input_data, operator, threshold, thresh_type='hard'):

--- a/modopt/signal/svd.py
+++ b/modopt/signal/svd.py
@@ -210,7 +210,7 @@ def svd_thresh_coef_fast(
 ):
     """Threshold the singular values coefficients.
 
-    This method threshold the input data by using singular value decomposition,
+    This method thresholds the input data by using singular value decomposition,
     but only computing the the greastest ``n_vals``  values.
 
     Parameters

--- a/modopt/tests/test_opt.py
+++ b/modopt/tests/test_opt.py
@@ -675,6 +675,11 @@ class ProximityTestCase(TestCase):
             weights,
         )
         self.lowrank = proximity.LowRankMatrix(10.0, thresh_type='hard')
+        self.lowrank_rank = proximity.LowRankMatrix(
+            10.0,
+            initial_rank=1,
+            thresh_type='hard',
+        )
         self.lowrank_ngole = proximity.LowRankMatrix(
             10.0,
             lowr_type='ngole',
@@ -763,6 +768,8 @@ class ProximityTestCase(TestCase):
         self.positivity = None
         self.sparsethresh = None
         self.lowrank = None
+        self.lowrank_rank = None
+        self.lowrank_ngole = None
         self.combo = None
         self.data1 = None
         self.data2 = None
@@ -841,6 +848,11 @@ class ProximityTestCase(TestCase):
             err_msg='Incorrect low rank operation: standard',
         )
 
+        npt.assert_almost_equal(
+            self.lowrank_rank.op(self.data3),
+            self.data4,
+            err_msg='Incorrect low rank operation: standard with rank',
+        )
         npt.assert_almost_equal(
             self.lowrank_ngole.op(self.data3),
             self.data5,

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,8 @@ per-file-ignores =
   #Justification: Needed to import matplotlib.pyplot
   modopt/plot/cost_plot.py: N802,WPS301
   #Todo: Investigate possible bug in find_n_pc function
-  modopt/signal/svd.py: WPS345
+  #Todo: Investigate darglint error
+  modopt/signal/svd.py: WPS345, DAR000
   #Todo: Check security of using system executable call
   modopt/signal/wavelet.py: S404,S603
   #Todo: Clean up tests


### PR DESCRIPTION
This PR adds a  Singular Value Threshold Operator. This does exactly the same that `LowRankMatrix` but faster (roughly 10 times, it depends on the threshold value, notebook and data available upon request). 

Basically instead of computing all the singular value, and perform the thresholding, we only compute the one above the threshold, which save a lot of computation. 

I left the legacy version for now, but this should act as a drop in replacement. 

![Screenshot from 2022-01-25 15-35-42](https://user-images.githubusercontent.com/77174042/150997485-1be31acd-03af-43a8-ae6b-dc899e783d21.png)