### PR TITLE
[lint] pydocstyle compliance.

### DIFF
--- a/develop.txt
+++ b/develop.txt
@@ -7,3 +7,4 @@ pytest-pep8>=1.0.6
 pytest-emoji>=0.2.0
 pytest-flake8>=1.0.7
 wemake-python-styleguide>=0.15.2
+pytest-pydocstyle>=2.2.0

--- a/modopt/opt/linear.py
+++ b/modopt/opt/linear.py
@@ -150,7 +150,6 @@ class LinearCombo(LinearParent):
     See Also
     --------
     LinearParent : parent class
-
     """
 
     def __init__(self, operators, weights=None):

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -993,7 +993,7 @@ class KSupportNorm(ProximityParent):
         :math:`\sum\theta(\alpha^*)=k` via a linear interpolation.
 
         Parameters
-        -----------
+        ----------
         alpha0: float
             A value for wich :math:`\sum\theta(\alpha^0) \leq k`
         alpha1: float

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,3 +89,8 @@ addopts =
   --cov-report=term
   --cov-report=xml
   --junitxml=pytest.xml
+
+[pydocstyle]
+convention=numpy
+match_dir= ^(?!(docs|\.)).*
+match= (?!(test_|setup)).*\.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,8 +89,7 @@ addopts =
   --cov-report=term
   --cov-report=xml
   --junitxml=pytest.xml
+  --pydocstyle
 
 [pydocstyle]
 convention=numpy
-match_dir= ^(?!(docs|\.)).*
-match= (?!(test_|setup)).*\.py


### PR DESCRIPTION
This PR fixes the few linting errors yielded by pydocstyle. 