### PR TITLE
Switch from progressbar to tqdm

### DIFF
--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -289,8 +289,8 @@ class SetUp(Observable):
 
         """
         if self.progress and progbar is None:
-            with tqdm(total=max_iter) as progbar:
-                self._iterations(max_iter, progbar=progbar)
+            with tqdm(total=max_iter) as pb:
+                self._iterations(max_iter, progbar=pb)
         elif progbar is not None:
             self._iterations(max_iter, progbar=progbar)
         else:
@@ -300,4 +300,14 @@ class SetUp(Observable):
         raise NotImplementedError
 
     def get_notify_observers_kwargs(self):
+        """Notify observers.
+
+        Return the mapping between the metrics call and the iterated
+        variables.
+
+        Returns
+        -------
+        notify_observers_kwargs : dict,
+           The mapping between the iterated variables
+        """
         raise NotImplementedError

--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -15,7 +15,7 @@ class SetUp(Observable):
     r"""Algorithm Set-Up.
 
     This class contains methods for checking the set-up of an optimisation
-    algotithm and produces warnings if they do not comply.
+    algorithm and produces warnings if they do not comply.
 
     Parameters
     ----------
@@ -38,7 +38,6 @@ class SetUp(Observable):
     --------
     modopt.base.observable.Observable : parent class
     modopt.base.observable.MetricObserver : definition of metrics
-
     """
 
     def __init__(
@@ -300,14 +299,14 @@ class SetUp(Observable):
         raise NotImplementedError
 
     def get_notify_observers_kwargs(self):
-        """Notify observers.
+        """Notify Observers.
 
         Return the mapping between the metrics call and the iterated
         variables.
 
-        Returns
-        -------
-        notify_observers_kwargs : dict,
-           The mapping between the iterated variables
+        Raises
+        ------
+        NotImplementedError
+            This method should be overriden by subclasses.
         """
         raise NotImplementedError

--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -294,3 +294,9 @@ class SetUp(Observable):
             self._iterations(max_iter, progbar=progbar)
         else:
             self._iterations(max_iter)
+
+    def _update(self):
+        raise NotImplementedError
+
+    def get_notify_observers_kwargs(self):
+        raise NotImplementedError

--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -266,7 +266,7 @@ class SetUp(Observable):
                     print(' - Converged!')
                 break
 
-            if progbar is not None:
+            if progbar:
                 progbar.update()
 
     def _run_alg(self, max_iter, progbar=None):
@@ -290,7 +290,7 @@ class SetUp(Observable):
         if self.progress and progbar is None:
             with tqdm(total=max_iter) as pb:
                 self._iterations(max_iter, progbar=pb)
-        elif progbar is not None:
+        elif progbar:
             self._iterations(max_iter, progbar=progbar)
         else:
             self._iterations(max_iter)

--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -4,7 +4,7 @@
 from inspect import getmro
 
 import numpy as np
-from progressbar import ProgressBar
+from tqdm.auto import tqdm
 
 from modopt.base import backend
 from modopt.base.observable import MetricObserver, Observable
@@ -268,10 +268,10 @@ class SetUp(Observable):
                     print(' - Converged!')
                 break
 
-            if not isinstance(progbar, type(None)):
-                progbar.update(idx)
+            if progbar is not None:
+                progbar.update()
 
-    def _run_alg(self, max_iter):
+    def _run_alg(self, max_iter, progbar=None):
         """Run algorithm.
 
         Run the update step of a given algorithm up to the maximum number of
@@ -287,11 +287,10 @@ class SetUp(Observable):
         progressbar.bar.ProgressBar
 
         """
-        if self.progress:
-            with ProgressBar(
-                redirect_stdout=True,
-                max_value=max_iter,
-            ) as progbar:
+        if self.progress and progbar is None:
+            with tqdm(total=max_iter) as progbar:
                 self._iterations(max_iter, progbar=progbar)
+        elif progbar is not None:
+            self._iterations(max_iter, progbar=progbar)
         else:
             self._iterations(max_iter)

--- a/modopt/opt/algorithms/base.py
+++ b/modopt/opt/algorithms/base.py
@@ -240,9 +240,8 @@ class SetUp(Observable):
         ----------
         max_iter : int
             Maximum number of iterations
-        progbar : progressbar.bar.ProgressBar
-            Progress bar (default is ``None``)
-
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
         """
         for idx in range(max_iter):
             self.idx = idx
@@ -281,10 +280,12 @@ class SetUp(Observable):
         ----------
         max_iter : int
             Maximum number of iterations
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
 
         See Also
         --------
-        progressbar.bar.ProgressBar
+        tqdm.tqdm
 
         """
         if self.progress and progbar is None:

--- a/modopt/opt/algorithms/forward_backward.py
+++ b/modopt/opt/algorithms/forward_backward.py
@@ -477,7 +477,8 @@ class ForwardBackward(SetUp):
         ----------
         max_iter : int, optional
             Maximum number of iterations (default is ``150``)
-
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
         """
         self._run_alg(max_iter, progbar)
 
@@ -760,7 +761,8 @@ class GenForwardBackward(SetUp):
         ----------
         max_iter : int, optional
             Maximum number of iterations (default is ``150``)
-
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
         """
         self._run_alg(max_iter, progbar=progbar)
 
@@ -1005,7 +1007,8 @@ class POGM(SetUp):
         ----------
         max_iter : int, optional
             Maximum number of iterations (default is ``150``)
-
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
         """
         self._run_alg(max_iter, progbar)
 

--- a/modopt/opt/algorithms/forward_backward.py
+++ b/modopt/opt/algorithms/forward_backward.py
@@ -764,7 +764,7 @@ class GenForwardBackward(SetUp):
         progbar: tqdm.tqdm
             Progress bar handle (default is ``None``)
         """
-        self._run_alg(max_iter, progbar=progbar)
+        self._run_alg(max_iter, progbar)
 
         # retrieve metrics results
         self.retrieve_outputs()

--- a/modopt/opt/algorithms/forward_backward.py
+++ b/modopt/opt/algorithms/forward_backward.py
@@ -467,7 +467,7 @@ class ForwardBackward(SetUp):
                 or self._cost_func.get_cost(self._x_new)
             )
 
-    def iterate(self, max_iter=150):
+    def iterate(self, max_iter=150, progbar=None):
         """Iterate.
 
         This method calls update until either the convergence criteria is met
@@ -479,7 +479,7 @@ class ForwardBackward(SetUp):
             Maximum number of iterations (default is ``150``)
 
         """
-        self._run_alg(max_iter)
+        self._run_alg(max_iter, progbar)
 
         # retrieve metrics results
         self.retrieve_outputs()
@@ -750,7 +750,7 @@ class GenForwardBackward(SetUp):
         if self._cost_func:
             self.converge = self._cost_func.get_cost(self._x_new)
 
-    def iterate(self, max_iter=150):
+    def iterate(self, max_iter=150, progbar=None):
         """Iterate.
 
         This method calls update until either convergence criteria is met or
@@ -762,7 +762,7 @@ class GenForwardBackward(SetUp):
             Maximum number of iterations (default is ``150``)
 
         """
-        self._run_alg(max_iter)
+        self._run_alg(max_iter, progbar=progbar)
 
         # retrieve metrics results
         self.retrieve_outputs()
@@ -995,7 +995,7 @@ class POGM(SetUp):
                 or self._cost_func.get_cost(self._x_new)
             )
 
-    def iterate(self, max_iter=150):
+    def iterate(self, max_iter=150, progbar=None):
         """Iterate.
 
         This method calls update until either convergence criteria is met or
@@ -1007,7 +1007,7 @@ class POGM(SetUp):
             Maximum number of iterations (default is ``150``)
 
         """
-        self._run_alg(max_iter)
+        self._run_alg(max_iter, progbar)
 
         # retrieve metrics results
         self.retrieve_outputs()

--- a/modopt/opt/algorithms/primal_dual.py
+++ b/modopt/opt/algorithms/primal_dual.py
@@ -225,7 +225,7 @@ class Condat(SetUp):
                 or self._cost_func.get_cost(self._x_new, self._y_new)
             )
 
-    def iterate(self, max_iter=150, n_rewightings=1):
+    def iterate(self, max_iter=150, n_rewightings=1, progbar=None):
         """Iterate.
 
         This method calls update until either convergence criteria is met or
@@ -239,12 +239,14 @@ class Condat(SetUp):
             Number of reweightings to perform (default is ``1``)
 
         """
-        self._run_alg(max_iter)
+        self._run_alg(max_iter, progbar)
 
         if not isinstance(self._reweight, type(None)):
             for _ in range(n_rewightings):
                 self._reweight.reweight(self._linear.op(self._x_new))
-                self._run_alg(max_iter)
+                if progbar is not None:
+                    progbar.reset(total=max_iter)
+                self._run_alg(max_iter, progbar)
 
         # retrieve metrics results
         self.retrieve_outputs()

--- a/modopt/opt/algorithms/primal_dual.py
+++ b/modopt/opt/algorithms/primal_dual.py
@@ -237,7 +237,8 @@ class Condat(SetUp):
             Maximum number of iterations (default is ``150``)
         n_rewightings : int, optional
             Number of reweightings to perform (default is ``1``)
-
+        progbar: tqdm.tqdm
+            Progress bar handle (default is ``None``)
         """
         self._run_alg(max_iter, progbar)
 

--- a/modopt/opt/algorithms/primal_dual.py
+++ b/modopt/opt/algorithms/primal_dual.py
@@ -245,7 +245,7 @@ class Condat(SetUp):
         if not isinstance(self._reweight, type(None)):
             for _ in range(n_rewightings):
                 self._reweight.reweight(self._linear.op(self._x_new))
-                if progbar is not None:
+                if progbar:
                     progbar.reset(total=max_iter)
                 self._run_alg(max_iter, progbar)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 importlib_metadata>=3.7.0
 numpy>=1.19.5
 scipy>=1.5.4
-progressbar2>=3.53.1
+tqdm>=4.64.0


### PR DESCRIPTION
This PR is my proposal to implement #216 

It works great with notebook and script, and make the output less clutter when running multiples optimizer sequentially. This allow for instance to have nested progress bar without flooding stdout.
It is obviously transparent to the end user, when no progressbar handle is manually provided.

An example of usage (taken from [pysap-fmri](https://github.com/paquiteau/pysap-fmri):
```python
progbar_main=trange(len(kspace_data))
progbar = tqdm(total=max_iter_per_frame)
for i in progbar_main:
  # only recreate gradient if the trajectory change.
  grad_op = self.get_grad_op(
      fourier_ops[i],
      input_data_writeable=True,
      **grad_kwargs)
  grad_op._obs_data = kspace_data[i, ...]
  opt = initialize_opt(opt_name=self.opt_name,
                           grad_op=grad_op,
                           linear_op=self.space_linear_op,
                           prox_op=self.space_prox_op,
                           x_init=next_init,
                           synthesis_init=False,
                           opt_kwargs={"cost": None},
                           metric_kwargs={})
  
  progbar.reset(total=max_iter_per_frame)
  opt.iterate(max_iter=max_iter_per_frame, progbar=progbar)
```
![image](https://user-images.githubusercontent.com/77174042/167956269-9f66f999-6d9e-43b7-8748-3c92c21a2161.png)
*Example of notebook output*