### PR TITLE
Add support for Plug'n Play algorithm

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -207,3 +207,14 @@ archivePrefix = {arXiv},
   journal = {Journal of the Royal Statistical Society Series B},
   doi = {10.1111/j.1467-9868.2005.00527.x}
 }
+
+@article{Ryu_Liu_Wang_Chen_Wang_Yin_2019,
+ title={Plug-and-Play Methods Provably Converge with Properly Trained Denoisers},
+ url={http://arxiv.org/abs/1905.05406},
+ DOI={10.48550/arXiv.1905.05406},
+ number={arXiv:1905.05406},
+ institution={arXiv},
+ author={Ryu, Ernest K. and Liu, Jialin and Wang, Sicheng and Chen, Xiaohan and Wang, Zhangyang and Yin, Wotao},
+ year={2019},
+ month={May}
+}

--- a/modopt/opt/algorithms/pnp.py
+++ b/modopt/opt/algorithms/pnp.py
@@ -112,7 +112,7 @@ class PnpFBS(SetUp):
     def _update(self):
         self._gradf.get_grad(self._x_old)
         # saves an (possibly expensive) array allocation
-        self._x_new = (-self._alpha) * self._grad.grad
+        self._x_new = (-self._alpha) * self._gradf.grad
         self._x_new += self._x_old
         self._x_new = self._proxg.op(self._x_new)
 

--- a/modopt/opt/algorithms/pnp.py
+++ b/modopt/opt/algorithms/pnp.py
@@ -56,7 +56,7 @@ class PnpADMM(SetUp):
         self._sigma = sigma
 
     def _update(self):
-        self._x_new = self._proxf.op(self._y_old - self._u_old)
+        self._x_new = self._proxf.op(self._y_old - self._u_old, extra_factor=self._alpha)
         self._y_new = self._proxg.op(self._x_new - self._u_old)
         self._u_new = self._u_old + self._x_new - self._y_new
 

--- a/modopt/opt/algorithms/pnp.py
+++ b/modopt/opt/algorithms/pnp.py
@@ -1,5 +1,4 @@
-"""Plug 'n play algorithms.
-
+r"""Plug 'n play algorithms.
 
 These algorithms solves
 
@@ -9,29 +8,36 @@ These algorithms solves
 
 from modopt.opt.algorithms import SetUp
 
-class PnpADMM(SetUp):
-    r"""Plug 'n Play ADMM.
 
-    Implements (PNP-ADMM) of :cite:`ryu2019`
+class PnpADMM(SetUp):
+    """Plug 'n Play ADMM.
+
+    Implements (PNP-ADMM) of :cite:`ryu2019` to solve
+
+    ..math :: \arg\min f(x) + g(x)
 
     Parameters
     ----------
     x: array
+        Initial Value
     proxf: Operator
         Data consistency function as a proximal operator.
     proxg: Operator
         Regularisation function (e.g. denoiser).
+    alpha: float, default 1
+        Data consistency parameter, analoguous to gradient step size.
     sigma: float,  default 1
-        Noise level parameter
+        Noise level parameter.
     """
+
     def __init__(
         self,
-            x,
-            proxf,
-            proxg,
-            alpha=1,
-            sigma=1,
-            **kwargs,
+        x,
+        proxf,
+        proxg,
+        alpha=1,
+        sigma=1,
+        **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -59,6 +65,7 @@ class PnpADMM(SetUp):
         self.xp.copyto(self._y_old, self._y_new)
         self.xp.copyto(self._u_old, self._u_new)
 
+
 class PnpFBS(SetUp):
     """Plug'n Play Forward Backward Splitting.
 
@@ -77,14 +84,15 @@ class PnpFBS(SetUp):
     sigma: float
         Noise level.
     """
+
     def __init__(
         self,
-            x,
-            gradf,
-            proxg,
-            alpha=1,
-            sigma=1,
-            **kwargs,
+        x,
+        gradf,
+        proxg,
+        alpha=1,
+        sigma=1,
+        **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -118,7 +126,6 @@ class PnpFBS(SetUp):
         -------
         dict
            The mapping between the iterated variables
-
         """
         return {
             'x_new': self._x_new,

--- a/modopt/opt/algorithms/pnp.py
+++ b/modopt/opt/algorithms/pnp.py
@@ -1,0 +1,138 @@
+"""Plug 'n play algorithms.
+
+
+These algorithms solves
+
+..math :: \mathrm{arg}\min_{x\in \mathbb{R}^d} f(x) + g(x)
+
+"""
+
+from modopt.opt.algorithms import SetUp
+
+class PnpADMM(SetUp):
+    r"""Plug 'n Play ADMM.
+
+    Implements (PNP-ADMM) of :cite:`ryu2019`
+
+    Parameters
+    ----------
+    x: array
+    proxf: Operator
+        Data consistency function as a proximal operator.
+    proxg: Operator
+        Regularisation function (e.g. denoiser).
+    sigma: float,  default 1
+        Noise level parameter
+    """
+    def __init__(
+        self,
+            x,
+            proxf,
+            proxg,
+            alpha=1,
+            sigma=1,
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # init iteration variables.
+        self._x_old = self.xp.copy(x)
+        self._x_new = self.xp.copy(x)
+        self._y_old = self.xp.copy(x)
+        self._y_new = self.xp.copy(x)
+        self._u_old = self.xp.copy(x)
+        self._u_new = self.xp.copy(x)
+
+        # algorithm parameters
+        self._proxf = proxf
+        self._proxg = proxg
+        self._alpha = alpha
+        self._sigma = sigma
+
+    def _update(self):
+        self._x_new = self._proxf.op(self._y_old - self._u_old)
+        self._y_new = self._proxg.op(self._x_new - self._u_old)
+        self._u_new = self._u_old + self._x_new - self._y_new
+
+        # Update iteration
+        self.xp.copyto(self._x_old, self._x_new)
+        self.xp.copyto(self._y_old, self._y_new)
+        self.xp.copyto(self._u_old, self._u_new)
+
+class PnpFBS(SetUp):
+    """Plug'n Play Forward Backward Splitting.
+
+    Implements (PNP-FBS) of :cite:`ryu2019`
+
+    Parameters
+    ----------
+    x: array
+        Initial estimation
+    gradf: Operator
+        Gradient of :math:`f`
+    proxg: Operator
+        Proximal operator or plug-in replacement for g
+    alpha: float
+        gradient descent step size
+    sigma: float
+        Noise level.
+    """
+    def __init__(
+        self,
+            x,
+            gradf,
+            proxg,
+            alpha=1,
+            sigma=1,
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # init iteration variables.
+        self._x_old = self.xp.copy(x)
+        self._x_new = self.xp.copy(x)
+
+        # algorithm parameters
+        self._gradf = gradf
+        self._proxg = proxg
+        self._alpha = alpha
+        self._sigma = sigma
+
+    def _update(self):
+        self._gradf.get_grad(self._x_old)
+        # saves an (possibly expensive) array allocation
+        self._x_new = (-self._alpha) * self._grad.grad
+        self._x_new += self._x_old
+        self._x_new = self._proxg.op(self._x_new)
+
+        # Update iteration
+        self.xp.copyto(self._x_old, self._x_new)
+
+    def get_notify_observers_kwargs(self):
+        """Notify observers.
+
+        Return the mapping between the metrics call and the iterated
+        variables.
+
+        Returns
+        -------
+        dict
+           The mapping between the iterated variables
+
+        """
+        return {
+            'x_new': self._x_new,
+            'idx': self.idx,
+        }
+
+    def retrieve_outputs(self):
+        """Retrieve outputs.
+
+        Declare the outputs of the algorithms as attributes: x_final,
+        y_final, metrics.
+
+        """
+        metrics = {}
+        for obs in self._observers['cv_metrics']:
+            metrics[obs.name] = obs.retrieve_metrics()
+        self.metrics = metrics

--- a/modopt/opt/algorithms/pnp.py
+++ b/modopt/opt/algorithms/pnp.py
@@ -10,7 +10,7 @@ from modopt.opt.algorithms import SetUp
 
 
 class PnpADMM(SetUp):
-    """Plug 'n Play ADMM.
+    r"""Plug 'n Play ADMM.
 
     Implements (PNP-ADMM) of :cite:`ryu2019` to solve
 
@@ -32,7 +32,7 @@ class PnpADMM(SetUp):
 
     def __init__(
         self,
-        x,
+        x_init,
         proxf,
         proxg,
         alpha=1,
@@ -42,12 +42,12 @@ class PnpADMM(SetUp):
         super().__init__(**kwargs)
 
         # init iteration variables.
-        self._x_old = self.xp.copy(x)
-        self._x_new = self.xp.copy(x)
-        self._y_old = self.xp.copy(x)
-        self._y_new = self.xp.copy(x)
-        self._u_old = self.xp.copy(x)
-        self._u_new = self.xp.copy(x)
+        self._x_old = self.xp.copy(x_init)
+        self._x_new = self.xp.copy(x_init)
+        self._y_old = self.xp.copy(x_init)
+        self._y_new = self.xp.copy(x_init)
+        self._u_old = self.xp.copy(x_init)
+        self._u_new = self.xp.copy(x_init)
 
         # algorithm parameters
         self._proxf = proxf
@@ -56,7 +56,10 @@ class PnpADMM(SetUp):
         self._sigma = sigma
 
     def _update(self):
-        self._x_new = self._proxf.op(self._y_old - self._u_old, extra_factor=self._alpha)
+        self._x_new = self._proxf.op(
+            self._y_old - self._u_old,
+            extra_factor=self._alpha,
+        )
         self._y_new = self._proxg.op(self._x_new - self._u_old)
         self._u_new = self._u_old + self._x_new - self._y_new
 
@@ -87,7 +90,7 @@ class PnpFBS(SetUp):
 
     def __init__(
         self,
-        x,
+        x_init,
         gradf,
         proxg,
         alpha=1,
@@ -97,8 +100,8 @@ class PnpFBS(SetUp):
         super().__init__(**kwargs)
 
         # init iteration variables.
-        self._x_old = self.xp.copy(x)
-        self._x_new = self.xp.copy(x)
+        self._x_old = self.xp.copy(x_init)
+        self._x_new = self.xp.copy(x_init)
 
         # algorithm parameters
         self._gradf = gradf

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -89,14 +89,19 @@ def grad2prox(grad_op, step):
 
     Parameters
     ----------
-    grad_operator: GradBase
+    grad_op: GradBase
         Gradient operator
     step: float
         Gradient descent step.
 
+    Returns
+    -------
+    ProximityParent:
+        Proximal operator performing gradient descent step.
+
     Notes
     -----
-    Let :math:`f` a differentiable function. It proximity operator is defined as:
+    Let :math:`f` a differentiable function. Its proximal operator is:
 
     ..math :: prox_{\lambda f}(x)=(I+\lambda\nabla f)^{-1}(x)
 

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -105,9 +105,9 @@ def grad2prox(grad_op, step):
     ..math :: prox_{\lambda f}(x)= (I - \lambda\nabla f)(x)
     """
 
-    def _op(x, step=step):
-        grad_op.get_grad(x)
-        return x - step * grad_op.grad
+    def _op(input_data, extra_factor=step):
+        grad_op.get_grad(input_data)
+        return input_data - extra_factor * grad_op.grad
 
     return ProximityParent(_op, grad_op.cost)
 

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -82,6 +82,36 @@ class ProximityParent(object):
         self._cost = check_callable(method)
 
 
+def grad2prox(grad_op, step):
+    r"""Generate a proximity operator from a gradient operator.
+
+    This use a first order approximation (See :ref:`Notes`)
+
+    Parameters
+    ----------
+    grad_operator: GradBase
+        Gradient operator
+    step: float
+        Gradient descent step.
+
+    Notes
+    -----
+    Let :math:`f` a differentiable function. It proximity operator is defined as:
+
+    ..math :: prox_{\lambda f}(x)=(I+\lambda\nabla f)^{-1}(x)
+
+    And a first order approximation yields
+
+    ..math :: prox_{\lambda f}(x)= (I - \lambda\nabla f)(x)
+    """
+
+    def _op(x):
+        grad_op.get_grad(x)
+        return x - step * grad_op.grad
+
+    return ProximityParent(_op, grad_op.cost)
+
+
 class IdentityProx(ProximityParent):
     """Identity Proxmity Operator.
 

--- a/modopt/opt/proximity.py
+++ b/modopt/opt/proximity.py
@@ -105,7 +105,7 @@ def grad2prox(grad_op, step):
     ..math :: prox_{\lambda f}(x)= (I - \lambda\nabla f)(x)
     """
 
-    def _op(x):
+    def _op(x, step=step):
         grad_op.get_grad(x)
         return x - step * grad_op.grad
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,8 @@ per-file-ignores =
   # - Rethink subscript slice assignment
   # - Reduce complexity of KSupportNorm
   # - Check bitwise operations
-  modopt/opt/proximity.py: WPS220,WPS231,WPS352,WPS362,WPS465,WPS506,WPS508
+  # - Nested function declaration
+  modopt/opt/proximity.py: WPS220,WPS231,WPS352,WPS362,WPS465,WPS506,WPS508, WPS430
   #Todo: Consider changing cwbReweight name
   modopt/opt/reweight.py: N801
   #Justification: Needed to import matplotlib.pyplot


### PR DESCRIPTION
This PR implements Plug'n Play Method, following the notation of [^1]. Two new algorithms joins the ModOpt Family: 
- PnP ADMM :  using the ADMM algorithm and variable splitting with no constraint compared to [^2]
- PnP FBS (a simpler version of Forward Backward, where no acceleration is performed.)

Also, to ease the use of PnP ADMM I also wrote a convertor from Gadient operator to Proximal operator.



[^1]: https://arxiv.org/pdf/1905.05406.pdf
[^2]: #263